### PR TITLE
chore: remove Python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 notion-client = "^2.2.1"
 pydantic-api-models-notion = "^0.0.19"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ keywords = ["notion", "pydantic", "api", "type-safe"]
 license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This project is using union types from https://peps.python.org/pep-0604/, thus minimum version is 3.10